### PR TITLE
Handle special characters on query args

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -10,7 +10,7 @@
     """,
 
     'author': "Yezileli Ilomo",
-    'website': "http://www.singo.africa",
+    'website': "https://github.com/yezyilomo/odoo-rest-api",
 
     # Categories can be used to filter modules in modules listing
     # Check https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/data/ir_module_category_data.xml

--- a/controllers/parser.py
+++ b/controllers/parser.py
@@ -1,4 +1,6 @@
-from pypeg2 import name, csl, List, parse, optional, contiguous, word
+import re
+
+from pypeg2 import List, contiguous, csl, name, optional, parse
 
 from .exceptions import QueryFormatError
 
@@ -15,16 +17,33 @@ class AllFields(str):
     grammar = '*'
 
 
-class Argument(List):
-    grammar = name(), ':', word
-
+class BaseArgument(List):
     @property
     def value(self):
         return self[0]
 
 
+class ArgumentWithoutQuotes(BaseArgument):
+    grammar = name(), ':', re.compile(r'[^,:"\'\)]+')
+
+
+class ArgumentWithSingleQuotes(BaseArgument):
+    grammar = name(), ':', "'", re.compile(r'[^\']+'), "'"
+
+
+class ArgumentWithDoubleQuotes(BaseArgument):
+    grammar = name(), ':', '"', re.compile(r'[^"]+'), '"'
+
+
 class Arguments(List):
-    grammar = optional(csl([Argument],separator=','))
+    grammar = optional(csl(
+        [
+            ArgumentWithoutQuotes,
+            ArgumentWithSingleQuotes,
+            ArgumentWithDoubleQuotes
+        ],
+        separator=','
+    ))
 
 
 class ArgumentsBlock(List):
@@ -73,7 +92,7 @@ class Block(List):
 
 # ParentField grammar,
 # We don't include `ExcludedField` here because
-# exclude operator(-) on a parent field should 
+# exclude operator(-) on a parent field should
 # raise syntax error, e.g {name, -location{city}}
 # `IncludedField` is a parent field and `Block`
 # contains its sub fields
@@ -87,7 +106,7 @@ class Parser(object):
     def get_parsed(self):
         parse_tree = parse(self._query, Block)
         return self._transform_block(parse_tree)
-    
+
     def _transform_block(self, block):
         fields = {
             "include": [],
@@ -102,7 +121,7 @@ class Parser(object):
         for field in block.body:
             # A field may be a parent or included field or excluded field
             field = self._transform_field(field)
-            
+
             if isinstance(field, dict):
                 # A field is a parent
                 fields["include"].append(field)
@@ -132,20 +151,21 @@ class Parser(object):
                         "field level"
                     )
                     raise QueryFormatError(msg)
-                    
+
             if add_include_all_operator:
                 # Make sure we include * operator
                 fields["include"].append("*")
         return fields
-    
+
     def _transform_field(self, field):
         # A field may be a parent or included field or excluded field
         if isinstance(field, ParentField):
             return self._transform_parent_field(field)
         elif isinstance(field, (IncludedField, ExcludedField, AllFields)):
             return field
-    
+
     def _transform_parent_field(self, parent_field):
         parent_field_name = str(parent_field.name)
         parent_field_value = self._transform_block(parent_field.block)
         return {parent_field_name: parent_field_value}
+        


### PR DESCRIPTION
Use single quote `'` and double quote `"` to escape special characters including `, : " ' {} ()`